### PR TITLE
Fix code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const escapeHtml = require('escape-html');
 const app = express()
 
 let txt = ""
@@ -12,19 +13,19 @@ app.get('/cookies', (req, res) => {
     //Recibir las cookies que  nos manda el usuario
     const cookies = req.query.cookies
 
-    res.send(cookies);
+    res.send(escapeHtml(cookies));
 })
 
 app.get('/grab', (req, res) => {
     const data = req.query.data
     //Guardamos la data que el usuario nos manda en una variable global
-    txt += data + ""
-    res.send(data);
+    txt += escapeHtml(data) + ""
+    res.send(escapeHtml(data));
 })
 
 app.get('/read', (req, res) =>{
     //Leemos el valor que nos envian a txt
-    res.send(txt)
+    res.send(escapeHtml(txt))
 })
 
 app.listen(3000, () => {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "escape-html": "^1.0.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/17alma41/datagrab/security/code-scanning/3](https://github.com/17alma41/datagrab/security/code-scanning/3)

To fix the problem, we need to sanitize the user input before it is used in the response. This can be done by using a library like `escape-html` to escape any potentially dangerous characters in the user input. This will prevent any malicious scripts from being executed in the user's browser.

We will:
1. Install the `escape-html` library.
2. Import the `escape-html` library in the file.
3. Use the `escape-html` function to sanitize the `data` and `txt` variables before sending them in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
